### PR TITLE
feat: add WPK file support

### DIFF
--- a/gui/models/wpk_file_model.py
+++ b/gui/models/wpk_file_model.py
@@ -1,0 +1,67 @@
+"""A custom model for displaying WPK files in a QListView."""
+
+from typing import Any
+from PySide6 import QtCore, QtWidgets
+
+from core.wpk.class_types import WPKEntryDataFlags
+from core.wpk.wpk_file import WPKFile
+
+
+class WPKFileModel(QtCore.QAbstractListModel):
+    """Custom model for displaying WPK files in a QListView."""
+
+    _file_names_cache: dict[int, str] = {}
+
+    def __init__(self, wpk_file: WPKFile, parent: QtCore.QObject | None = None):
+        super().__init__(parent)
+
+        if isinstance(parent, QtWidgets.QWidget):
+            self._loading_icon = parent.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_BrowserReload)
+            self._encrypted_icon = parent.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MessageBoxWarning)
+            self._errored_icon = parent.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_MessageBoxCritical)
+            self._file_icon = parent.style().standardIcon(QtWidgets.QStyle.StandardPixmap.SP_FileIcon)
+
+        self._wpk_file = wpk_file
+
+    def rowCount(self, parent: QtCore.QModelIndex | QtCore.QPersistentModelIndex = QtCore.QModelIndex()) -> int:  # type: ignore[override]
+        return len(self._wpk_file.indices)
+
+    def data(self, index: QtCore.QModelIndex | QtCore.QPersistentModelIndex,
+             role: int = QtCore.Qt.ItemDataRole.DisplayRole) -> Any:  # type: ignore[override]
+        if not index.isValid():
+            return None
+        if role == QtCore.Qt.ItemDataRole.DisplayRole:
+            filename = self.get_filename(index)
+            if not self._wpk_file.is_entry_loaded(index.row()):
+                return filename
+
+            entry = self._wpk_file.read_entry(index.row())
+            if entry.data_flags & WPKEntryDataFlags.ERROR:
+                return f"{filename} (Error)"
+            if entry.data_flags & WPKEntryDataFlags.ENCRYPTED:
+                return f"{filename} (Encrypted)"
+            return filename
+        if role == QtCore.Qt.ItemDataRole.DecorationRole:
+            if not self._wpk_file.is_entry_loaded(index.row()):
+                return self._loading_icon
+
+            entry = self._wpk_file.read_entry(index.row())
+            if entry.data_flags & WPKEntryDataFlags.ERROR:
+                return self._errored_icon
+            if entry.data_flags & WPKEntryDataFlags.ENCRYPTED:
+                return self._encrypted_icon
+            return self._file_icon
+        if role == QtCore.Qt.ItemDataRole.UserRole:
+            return self._wpk_file.indices[index.row()]
+        return None
+
+    def get_filename(self, index: QtCore.QModelIndex | QtCore.QPersistentModelIndex, invalidate_cache: bool = False) -> str:
+        """Get the filename for a given index."""
+        if not index.isValid():
+            return ""
+        if index.row() in self._file_names_cache and not invalidate_cache:
+            return self._file_names_cache[index.row()]
+
+        filename = self._wpk_file.indices[index.row()].filename
+        self._file_names_cache[index.row()] = filename
+        return filename

--- a/gui/utils/viewer.py
+++ b/gui/utils/viewer.py
@@ -4,6 +4,7 @@ from typing import Type
 from PySide6 import QtWidgets
 
 from core.npk.class_types import NPKEntry
+from core.wpk.class_types import WPKEntry
 from gui.widgets.code_editor import CodeEditor
 from gui.widgets.hex_viewer import HexViewer
 from gui.widgets.mesh_viewer.viewer_widget import MeshViewer
@@ -65,15 +66,16 @@ def set_data_for_viewer(viewer: QtWidgets.QWidget, data: bytes | None, extension
         else:
             viewer.read_bnk(data, extension)
 
-def set_entry_for_viewer(viewer: QtWidgets.QWidget, data: NPKEntry | None):
-    """
-    Set the data for the viewer.
-    
-    :param viewer: The viewer to set the data for.
-    :param data: The NPK entry data to set.
-    """
-    set_data_for_viewer(viewer, data.data if data is not None else None, \
-                         data.extension if data is not None else "dat")
+def set_entry_for_viewer(
+    viewer: QtWidgets.QWidget, data: NPKEntry | WPKEntry | None
+):
+    """Set the entry data for the viewer."""
+
+    set_data_for_viewer(
+        viewer,
+        data.data if data is not None else None,
+        data.extension if data is not None else "dat",
+    )
 
 def get_viewer_display_name(viewer: QtWidgets.QWidget | type) -> str:
     """

--- a/gui/utils/wpk.py
+++ b/gui/utils/wpk.py
@@ -1,0 +1,11 @@
+"""WPK file utility functions."""
+
+from typing import cast
+
+from PySide6 import QtCore
+
+from core.wpk.wpk_file import WPKFile
+
+def get_wpk_file() -> WPKFile | None:
+    """Get the current WPK file from the application instance."""
+    return cast(QtCore.QCoreApplication, QtCore.QCoreApplication.instance()).property("wpk_file")

--- a/gui/widgets/wpk_file_list.py
+++ b/gui/widgets/wpk_file_list.py
@@ -1,0 +1,199 @@
+"""Custom QListView to display WPK files."""
+
+import os
+from PySide6 import QtCore, QtWidgets
+
+from core.wpk.class_types import WPKEntry
+from gui.models.wpk_file_model import WPKFileModel
+from gui.utils.wpk import get_wpk_file
+from gui.utils.viewer import ALL_VIEWERS, get_viewer_display_name
+
+
+class WPKFileList(QtWidgets.QListView):
+    """Custom QListView to display WPK files."""
+
+    preview_entry = QtCore.Signal(int, WPKEntry)
+    open_entry = QtCore.Signal(int, WPKEntry)
+    open_entry_with = QtCore.Signal(int, WPKEntry, type)
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None):
+        super().__init__(parent)
+
+        self._disabled = False
+        self._select_after_enabled: QtCore.QModelIndex | None = None
+
+        self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.setDragEnabled(False)
+        self.setAcceptDrops(False)
+        self.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.show_context_menu)
+
+        self.doubleClicked.connect(self.on_item_double_clicked)
+
+    def setDisabled(self, disabled: bool):  # noqa: N802 - Qt method naming
+        """Set the disabled state of the list view."""
+        if disabled:
+            self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.NoSelection)
+            self.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+            self.setProperty("disabled", True)
+        else:
+            self.setSelectionMode(QtWidgets.QAbstractItemView.SelectionMode.ExtendedSelection)
+            self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
+            self.setProperty("disabled", None)
+        self.style().unpolish(self)
+        self.style().polish(self)
+
+        self._disabled = disabled
+
+        if self._select_after_enabled:
+            self.selectionModel().select(
+                self._select_after_enabled,
+                QtCore.QItemSelectionModel.SelectionFlag.ClearAndSelect,
+            )
+            self.on_current_changed(self._select_after_enabled, QtCore.QModelIndex())
+            self._select_after_enabled = None
+
+    def disabled(self) -> bool:
+        """Get the disabled state of the list view."""
+        return self._disabled
+
+    def model(self) -> WPKFileModel:  # type: ignore[override]
+        """Get the current model of the list view."""
+        return super().model()  # type: ignore[return-value]
+
+    def refresh_wpk_file(self) -> None:
+        """Refresh the model with the current WPK file."""
+        wpk_file = get_wpk_file()
+        if wpk_file is None:
+            self.setModel(None)
+        else:
+            self.setModel(WPKFileModel(wpk_file, self))
+            self.selectionModel().currentChanged.connect(self.on_current_changed)
+
+    def on_current_changed(self, current: QtCore.QModelIndex, previous: QtCore.QModelIndex) -> None:  # noqa: ARG002
+        if self._disabled:
+            self._select_after_enabled = current
+            return
+        wpk_file = get_wpk_file()
+        if not self.model() or wpk_file is None:
+            return
+        row_index = current.row()
+        entry = wpk_file.read_entry(row_index)
+        self.preview_entry.emit(row_index, entry)
+
+    def on_item_double_clicked(self, index: QtCore.QModelIndex) -> None:
+        if self._disabled:
+            return
+        wpk_file = get_wpk_file()
+        if not self.model() or wpk_file is None:
+            return
+        row_index = index.row()
+        entry = wpk_file.read_entry(row_index)
+        self.open_entry.emit(row_index, entry)
+
+    def show_context_menu(self, position):
+        wpk_file = get_wpk_file()
+        if not self.model() or wpk_file is None:
+            return
+        indexes = self.selectedIndexes()
+        if not indexes:
+            return
+        menu = QtWidgets.QMenu(self)
+        extract = menu.addAction("Extract")
+        extract.triggered.connect(lambda: self.extract_entries(indexes))
+
+        menu.addSeparator()
+        for viewer in ALL_VIEWERS:
+            viewer_action = menu.addAction("Open in " + get_viewer_display_name(viewer))
+            viewer_action.triggered.connect(
+                lambda _checked, v=viewer: self.open_entries_with(indexes, v)
+            )
+        if len(indexes) == 1:
+            menu.addSeparator()
+            rename = menu.addAction("Rename")
+            rename.triggered.connect(lambda: self.show_rename_dialog(indexes[0]))
+        menu.exec(self.viewport().mapToGlobal(position))
+
+    def open_entries_with(self, indexes: list[QtCore.QModelIndex], viewer: type) -> None:
+        wpk_file = get_wpk_file()
+        if wpk_file is None:
+            return
+        for index in indexes:
+            row = index.row()
+            entry = wpk_file.read_entry(row)
+            self.open_entry_with.emit(row, entry, viewer)
+
+    def extract_entries(self, indexes: list[QtCore.QModelIndex]) -> None:
+        wpk_file = get_wpk_file()
+        if not self.model() or wpk_file is None:
+            return
+        if len(indexes) == 1:
+            index = indexes[0]
+            row_index = index.row()
+            filename = self.model().get_filename(index)
+            entry = wpk_file.read_entry(row_index)
+            file_path, _ = QtWidgets.QFileDialog.getSaveFileName(
+                self, "Extract File", filename, "All Files (*.*)"
+            )
+            if file_path:
+                try:
+                    with open(file_path, "wb") as f:
+                        f.write(entry.data)
+                    QtWidgets.QMessageBox.information(
+                        self, "Success", f"File extracted to {file_path}"
+                    )
+                except Exception as e:  # pragma: no cover - UI message
+                    QtWidgets.QMessageBox.critical(
+                        self, "Error", f"Failed to extract file: {str(e)}"
+                    )
+        else:
+            dir_path = QtWidgets.QFileDialog.getExistingDirectory(
+                self,
+                "Select Directory to Extract Files",
+                "",
+                QtWidgets.QFileDialog.Option.ShowDirsOnly,
+            )
+            if dir_path:
+                try:
+                    success_count = 0
+                    fail_count = 0
+                    for index in indexes:
+                        row_index = index.row()
+                        filename = self.model().get_filename(index)
+                        safe_filename = os.path.basename(filename) or f"unknown_file_{row_index}"
+                        file_path = os.path.join(dir_path, safe_filename)
+                        entry = wpk_file.read_entry(row_index)
+                        try:
+                            with open(file_path, "wb") as f:
+                                f.write(entry.data)
+                            success_count += 1
+                        except Exception:
+                            fail_count += 1
+                    message = f"Extracted {success_count} files to {dir_path}"
+                    if fail_count > 0:
+                        message += f"\n{fail_count} files failed to extract"
+                    QtWidgets.QMessageBox.information(self, "Extraction Complete", message)
+                except Exception as e:  # pragma: no cover - UI message
+                    QtWidgets.QMessageBox.critical(
+                        self, "Error", f"Failed to extract files: {str(e)}"
+                    )
+
+    def show_rename_dialog(self, index: QtCore.QModelIndex) -> None:
+        wpk_file = get_wpk_file()
+        if not self.model() or wpk_file is None:
+            return
+        entry_index = wpk_file.indices[index.row()]
+        new_name, ok = QtWidgets.QInputDialog.getText(
+            self,
+            "Rename File",
+            f"Enter new name for {self.model().get_filename(index)}:",
+            QtWidgets.QLineEdit.EchoMode.Normal,
+            "",
+        )
+        if ok and new_name:
+            entry_index.filename = new_name
+            if index.row() in wpk_file.entries:
+                wpk_file.entries[index.row()].filename = new_name
+            model = self.model()
+            model.get_filename(index, invalidate_cache=True)
+            self.update(model.index(index.row()))


### PR DESCRIPTION
## Summary
- add WPKFileModel and WPKFileList to browse WPK archives
- allow viewer utilities and preview widget to handle WPKEntry objects
- extend main window with menu actions to open and unload IDX/WPK files

## Testing
- `pytest -q` *(fails: pyenv: version `3.13.5` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a426f9672083288410d7e58d3ccedd