### PR TITLE
Add WPK extraction support and detection utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Download the latest release at [GitHub Releases](https://github.com/MarcosVLl2/N
 1. Run `neoxtractor.exe` directly to start in GUI mode.
 2. Some games' NPK (EXPK) requires XOR key to be set. We have default profile for Onmyoji currently. To set XOR key, create a new config in Config Manager.
 ![Config Manager tutorial](assets/set-xor-key.png)
-3. Open the NPK file.
+3. Open the NPK file. IDX/WPK archives are also supported and can be opened in the same way.
 
 #### Introduction
 
@@ -46,7 +46,15 @@ Within the file list area, you can right click to operate on the selected entrie
 
 ### CLI
 
-Command-line interface is still being worked on.
+Extract WPK archives from the command line:
+
+```bash
+python main.py wpk <IDX_OR_WPK_PATH> [WPK_PATH] [-k KEY] [-o OUTPUT_DIR]
+```
+
+Provide either the `.idx` or `.wpk` file (or both). When only one path is
+given the companion file is located automatically. Use `-k`/`--key` to supply a
+decryption key when required and `-o`/`--output` to select the output directory.
 
 ## Development
 

--- a/core/args.py
+++ b/core/args.py
@@ -1,6 +1,9 @@
 """Argument management module."""
 
 import argparse
+import os
+
+from core.detection import detect_file_type
 
 from core.build_info import BuildInfo
 
@@ -17,8 +20,34 @@ _subparsers = parser.add_subparsers(help="subcommand help", dest="subcommand")
 
 gui_parser = _subparsers.add_parser('gui', help='Run the NeoXtractor GUI')
 
+wpk_parser = _subparsers.add_parser('wpk', help='Extract an IDX/WPK archive')
+wpk_parser.add_argument('path', help='Path to IDX or WPK file')
+wpk_parser.add_argument('wpk_path', nargs='?', help='Optional WPK file path if the first argument is IDX')
+wpk_parser.add_argument('-o', '--output', dest='output', default='.', help='Output directory')
+wpk_parser.add_argument('-k', '--key', dest='key', type=lambda x: int(x, 0), help='Decryption key (hex or int)')
+
 arguments = argparse.Namespace()
 
 def parse_args():
     """Parse arguments."""
     parser.parse_args(namespace=arguments)
+
+    if arguments.subcommand == 'wpk':
+        from core.wpk.wpk_file import WPKFile
+        from core.wpk.class_types import WPKReadOptions
+
+        idx_path = arguments.path
+        wpk_path = arguments.wpk_path
+
+        detected = detect_file_type(idx_path)
+        if detected == 'wpk':
+            wpk_path = idx_path
+            idx_path = os.path.splitext(idx_path)[0] + '.idx'
+        elif detected == 'idx' and wpk_path is None:
+            wpk_path = os.path.splitext(idx_path)[0] + '.wpk'
+        elif wpk_path and detect_file_type(wpk_path) == 'idx':
+            idx_path, wpk_path = wpk_path, idx_path
+
+        options = WPKReadOptions(decryption_key=arguments.key)
+        with WPKFile(idx_path, wpk_path, options) as wpk_file:
+            wpk_file.extract_all(arguments.output)

--- a/core/detection.py
+++ b/core/detection.py
@@ -1,0 +1,57 @@
+"""Simple file format detection utilities.
+
+This module provides helper functions to detect container formats
+based on their header signatures. Currently supports detection of
+IDX and WPK files.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+IDX_SIGNATURE = b"IDX\x00"
+"""Magic bytes present at the beginning of IDX files."""
+
+WPK_SIGNATURE = b"WPK\x00"
+"""Magic bytes present at the beginning of WPK files."""
+
+def is_idx_signature(data: bytes) -> bool:
+    """Check if the given data starts with the IDX signature.
+
+    Args:
+        data: Initial bytes from a file.
+
+    Returns:
+        bool: ``True`` if the data matches the IDX signature.
+    """
+    return len(data) >= len(IDX_SIGNATURE) and data.startswith(IDX_SIGNATURE)
+
+def is_wpk_signature(data: bytes) -> bool:
+    """Check if the given data starts with the WPK signature.
+
+    Args:
+        data: Initial bytes from a file.
+
+    Returns:
+        bool: ``True`` if the data matches the WPK signature.
+    """
+    return len(data) >= len(WPK_SIGNATURE) and data.startswith(WPK_SIGNATURE)
+
+def detect_file_type(path: str) -> Optional[str]:
+    """Detect the file type of the provided path.
+
+    Args:
+        path: Path to the file to probe.
+
+    Returns:
+        The detected type (``"idx"`` or ``"wpk"``) or ``None`` if
+        the file type could not be determined.
+    """
+    max_len = max(len(IDX_SIGNATURE), len(WPK_SIGNATURE))
+    with open(path, "rb") as file:
+        header = file.read(max_len)
+    if is_idx_signature(header):
+        return "idx"
+    if is_wpk_signature(header):
+        return "wpk"
+    return None


### PR DESCRIPTION
## Summary
- add detection helpers for IDX and WPK header signatures
- add `wpk` CLI command to extract IDX/WPK archives with optional key
- document WPK usage and GUI support in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a42aabc6348328af38e6e6f4c7e3ae