### PR TITLE
Support WPK entries in detection and filtering

### DIFF
--- a/core/npk/detection.py
+++ b/core/npk/detection.py
@@ -1,7 +1,8 @@
-"""Utilities for file format detection in NPK files."""
+"""Utilities for file format detection in NPK and WPK files."""
 
 from core.npk.enums import NPKEntryFileCategories
 from core.npk.class_types import NPKEntryDataFlags
+from core.wpk.class_types import WPKEntryDataFlags
 
 def is_binary(data: bytes):
     """Check if the data is binary.
@@ -22,7 +23,7 @@ def is_binary(data: bytes):
         return True
     return False
 
-def _get_binary_ext(data: bytes, flags: NPKEntryDataFlags):
+def _get_binary_ext(data: bytes, flags: NPKEntryDataFlags | WPKEntryDataFlags):
     """Check for binary file signatures."""
     if data[:3] == b'PVR':
         return 'pvr'
@@ -117,7 +118,7 @@ def _get_binary_ext(data: bytes, flags: NPKEntryDataFlags):
 
     return None
 
-def _get_text_ext(data: bytes, flags: NPKEntryDataFlags):
+def _get_text_ext(data: bytes, flags: NPKEntryDataFlags | WPKEntryDataFlags):
     """Check for text file signatures."""
     if data[:18] == b'from typing import ':
         return 'pyi'
@@ -235,7 +236,7 @@ def _get_text_ext(data: bytes, flags: NPKEntryDataFlags):
 
     return None
 
-def get_ext(data: bytes, flags: NPKEntryDataFlags):
+def get_ext(data: bytes, flags: NPKEntryDataFlags | WPKEntryDataFlags):
     """Get the file extension based on file signature.
 
     Args:
@@ -248,7 +249,8 @@ def get_ext(data: bytes, flags: NPKEntryDataFlags):
     if len(data) == 0:
         return 'empty'
 
-    if flags & NPKEntryDataFlags.TEXT:
+    text_flag = type(flags).TEXT
+    if flags & text_flag:
         ext = _get_text_ext(data, flags)
         if ext:
             return ext

--- a/gui/archive_entry_filter.py
+++ b/gui/archive_entry_filter.py
@@ -1,16 +1,16 @@
-"""Provides a filter for NPK entries in the NPK file list."""
+"""Provides a filter for archive entries in the file list."""
 
 from core.npk.enums import NPKEntryFileCategories
-from core.npk.class_types import NPKEntryDataFlags
 from gui.utils.npk import get_npk_file, ransack_agent
+from gui.utils.wpk import get_wpk_file
 from gui.widgets.npk_file_list import NPKFileList
+from gui.widgets.wpk_file_list import WPKFileList
 
-class NPKEntryFilter:
-    """
-    This class is used to filter NPK entries based on given conditions.
-    """
 
-    def __init__(self, list_view: NPKFileList):
+class ArchiveEntryFilter:
+    """Filter entries from either NPK or WPK file lists."""
+
+    def __init__(self, list_view: NPKFileList | WPKFileList):
         self._list_view = list_view
         self.filter_string = ""
         self.filter_type: NPKEntryFileCategories | None = None
@@ -20,22 +20,17 @@ class NPKEntryFilter:
         self.mesh_biped_head = False
 
     def apply_filter(self):
-        """
-        Filters the NPK entries based on the filter string.
-
-        :param npk_entries: List of NPK entries to be filtered.
-        :return: Filtered list of NPK entries.
-        """
+        """Filter entries based on the current settings."""
         if self._list_view.disabled():
             return
 
         model = self._list_view.model()
-        npk_file = get_npk_file()
-        if not model or not npk_file:
+        archive_file = get_npk_file() or get_wpk_file()
+        if not model or not archive_file:
             return
 
         for row in range(model.rowCount()):
-            npk_entry = npk_file.read_entry(row)
+            entry = archive_file.read_entry(row)
             filename_lower = model.get_filename(model.index(row)).lower()
 
             if self.include_text == self.include_binary == False:
@@ -43,10 +38,12 @@ class NPKEntryFilter:
                 self._list_view.setRowHidden(row, True)
                 continue
 
+            text_flag = type(entry.data_flags).TEXT
             if self.include_text != self.include_binary:
                 # If only one is checked, hide the other
-                if self.include_text and not npk_entry.data_flags & NPKEntryDataFlags.TEXT or \
-                     (self.include_binary and npk_entry.data_flags & NPKEntryDataFlags.TEXT):
+                if self.include_text and not entry.data_flags & text_flag or (
+                    self.include_binary and entry.data_flags & text_flag
+                ):
                     self._list_view.setRowHidden(row, True)
                     continue
 
@@ -57,12 +54,10 @@ class NPKEntryFilter:
 
             # Category filtering
             if self.filter_type is None:
-                # No filter type set, show all
                 show_item = True
-            elif self.filter_type == npk_entry.category:
+            elif self.filter_type == entry.category:
                 if self.filter_type == NPKEntryFileCategories.MESH:
-                    # Only do the expensive biped head check if needed
-                    show_item = not self.mesh_biped_head or ransack_agent(npk_entry.data, "biped head")
+                    show_item = not self.mesh_biped_head or ransack_agent(entry.data, "biped head")
                 else:
                     show_item = True
             else:

--- a/gui/windows/main_window.py
+++ b/gui/windows/main_window.py
@@ -14,7 +14,7 @@ from core.wpk.wpk_file import WPKFile
 from core.wpk.class_types import WPKEntry
 from gui.config_manager import ConfigManager
 from gui.models.npk_file_model import NPKFileModel
-from gui.npk_entry_filter import NPKEntryFilter
+from gui.archive_entry_filter import ArchiveEntryFilter
 from gui.settings_manager import SettingsManager
 from gui.utils.config import save_config_manager_to_settings
 from gui.utils.viewer import ALL_VIEWERS, find_best_viewer, get_viewer_display_name
@@ -96,7 +96,7 @@ class MainWindow(QtWidgets.QMainWindow):
             widget.open_entry.connect(open_tab_window_for_entry)
             widget.open_entry_with.connect(open_tab_window_for_entry)
 
-        self.filter = NPKEntryFilter(self.npk_list_widget)
+        self.filter = ArchiveEntryFilter(self.npk_list_widget)
 
         self.filter_section = QtWidgets.QVBoxLayout()
 
@@ -475,7 +475,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.wpk_list_widget.setVisible(False)
         self.filter_section.setVisible(True)
         if self.filter is None:
-            self.filter = NPKEntryFilter(self.npk_list_widget)
+            self.filter = ArchiveEntryFilter(self.npk_list_widget)
 
         self._loading_cancelled = False
 


### PR DESCRIPTION
## Summary
- Allow `get_ext` to accept WPK entry flags so WPK files reuse NPK binary detection
- Generalize NPK entry filter into `ArchiveEntryFilter` that works for NPK and WPK lists
- Update main window to use the new archive entry filter

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a42c8f0e40832883d7d1fa5914ebe1